### PR TITLE
Update testsing to node.js 20/22/24 and fix some checker issues

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           lint: true
@@ -36,11 +36,12 @@ jobs:
   # Runs adapter tests on all supported node versions and OSes
   adapter-tests:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
+    needs: [check-and-lint]
 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -74,7 +75,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-deploy@v1
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The data point CalculatedRemaining/JsonForEcharts (calculated remaining quantity
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) Adapter requires node.js 20 and admin 6.17.14 now
+
 ### 1.3.5 (2024-08-08)
 
 js-controller dependency updated

--- a/io-package.json
+++ b/io-package.json
@@ -115,8 +115,7 @@
       "mex",
       "heizoel",
       "heizoel24",
-      "ioBroker.heizoel24",
-      "ioBroker"
+      "ioBroker.heizoel24"
     ],
     "licenseInformation": {
       "type": "free",
@@ -146,7 +145,7 @@
     ],
     "globalDependencies": [
       {
-        "admin": ">=5.1.13"
+        "admin": ">=6.17.14"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/ltspicer/ioBroker.heizoel24-mex",
   "license": "MIT",
   "keywords": [
+    "ioBroker",
     "mex",
     "heizoel",
     "heizoel24"
@@ -18,7 +19,7 @@
     "url": "git@github.com:ltspicer/ioBroker.heizoel24-mex.git"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.2.3",


### PR DESCRIPTION
This PR includes the following changes:
- common actions at workflow test-and-release.yml use node.js 22 now
- adapter testing matrix at workflow test-and-release.yml uses node.js 20, 22 and 24 now
- package.json has been adapted, adapetr requies node.js 20 minimum now
- io-package.json ahs been adapted to require admin 6.x.x now

Please check and merge

Please note that due to encreaed node.js requirement the next release containing these change must be at least a minor release - not a patch-release. 